### PR TITLE
datesEnabled property (Will override datesDisabled and daysOfWeekDisabled)

### DIFF
--- a/docs/options.rst
+++ b/docs/options.rst
@@ -151,6 +151,16 @@ String, Array.  Default: []
 
 Array of date strings or a single date string formatted in the given date format
 
+.. _datesEnabled:
+
+
+datesEnabled
+-------------
+
+String, Array.  Default: []
+
+Array of date strings or a single date string formatted in the given date format. Will override datesDisabled and daysOfWeekDisabled.
+
 .. _daysOfWeekDisabled:
 
 

--- a/docs/options.rst
+++ b/docs/options.rst
@@ -151,16 +151,6 @@ String, Array.  Default: []
 
 Array of date strings or a single date string formatted in the given date format
 
-.. _datesEnabled:
-
-
-datesEnabled
--------------
-
-String, Array.  Default: []
-
-Array of date strings or a single date string formatted in the given date format. Will override datesDisabled and daysOfWeekDisabled.
-
 .. _daysOfWeekDisabled:
 
 
@@ -173,6 +163,16 @@ Days of the week that should be disabled. Values are 0 (Sunday) to 6 (Saturday).
 
 .. figure:: _static/screenshots/option_daysofweekdisabled.png
     :align: center
+
+.. _datesEnabled:
+
+
+datesEnabled
+-------------
+
+String, Array.  Default: []
+
+Array of date strings or a single date string formatted in the given date format. Will override datesDisabled and daysOfWeekDisabled.
 
 .. _daysOfWeekHighlighted:
 

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -153,7 +153,8 @@
 			endDate: this._o.endDate,
 			daysOfWeekDisabled: this.o.daysOfWeekDisabled,
 			daysOfWeekHighlighted: this.o.daysOfWeekHighlighted,
-			datesDisabled: this.o.datesDisabled
+			datesDisabled: this.o.datesDisabled,
+			datesEnabled: this.o.datesEnabled
 		});
 
 		this._allow_update = false;
@@ -277,6 +278,16 @@
 			}
 			o.datesDisabled = $.map(o.datesDisabled, function(d){
 				return DPGlobal.parseDate(d, format, o.language, o.assumeNearbyYear);
+			});
+
+			o.datesEnabled = o.datesEnabled||[];
+			if (!$.isArray(o.datesEnabled)) {
+				var datesEnabled = [];
+				datesEnabled.push(DPGlobal.parseDate(o.datesEnabled, format, o.language));
+				o.datesEnabled = datesEnabled;
+			}
+			o.datesEnabled = $.map(o.datesEnabled,function(d){
+				return DPGlobal.parseDate(d, format, o.language);
 			});
 
 			var plc = String(o.orientation).toLowerCase().split(/\s+/g),
@@ -661,6 +672,12 @@
 			this._process_options({datesDisabled: datesDisabled});
 			this.update();
 			return this;
+		},
+
+		setDatesEnabled: function(datesEnabled){
+			this._process_options({datesEnabled: datesEnabled});
+			this.update();
+			this.updateNavArrows();
 		},
 
 		place: function(){
@@ -1389,10 +1406,14 @@
 
 		dateIsDisabled: function(date){
 			return (
-				this.weekOfDateIsDisabled(date) ||
+				(this.o.datesEnabled.length === 0 ||
+				$.grep(this.o.datesEnabled, function (d) {
+					return isUTCEquals(date, d);
+				}).length === 0) &&
+				(this.weekOfDateIsDisabled(date) ||
 				$.grep(this.o.datesDisabled, function(d){
 					return isUTCEquals(date, d);
-				}).length > 0
+				}).length > 0)
 			);
 		},
 
@@ -1696,6 +1717,7 @@
 		daysOfWeekDisabled: [],
 		daysOfWeekHighlighted: [],
 		datesDisabled: [],
+		datesEnabled: [],
 		endDate: Infinity,
 		forceParse: true,
 		format: 'mm/dd/yyyy',

--- a/tests/suites/options.js
+++ b/tests/suites/options.js
@@ -739,6 +739,38 @@ test('DatesDisabled as attribute', function(){
     ok(!target.hasClass('disabled'), 'Day of week is enabled');
 });
 
+test('DatesEnabled', function(){
+    var input = $('<input />')
+                .appendTo('#qunit-fixture')
+                .val('2012-10-26')
+                .datepicker({
+                    format: 'yyyy-mm-dd',
+                    datesDisabled: ['2012-10-1', '2012-10-10', '2012-10-20'],
+                    daysOfWeekDisabled: [1,3,6],
+                    datesEnabled: ['2012-10-1', '2012-10-10', '2012-10-20']
+                }),
+        dp = input.data('datepicker'),
+        picker = dp.picker,
+        target;
+
+    input.focus();
+    target = picker.find('.datepicker-days tbody td:nth(1)');
+    ok(!target.hasClass('disabled'), 'Day of week is disabled');
+    ok(!target.hasClass('disabled-date'), 'Date is disabled');
+    target = picker.find('.datepicker-days tbody td:nth(2)');
+    ok(!target.hasClass('disabled'), 'Day of week is disabled');
+    target = picker.find('.datepicker-days tbody td:nth(10)');
+    ok(!target.hasClass('disabled'), 'Day of week is disabled');
+    ok(!target.hasClass('disabled-date'), 'Date is disabled');
+    target = picker.find('.datepicker-days tbody td:nth(11)');
+    ok(!target.hasClass('disabled'), 'Day of week is disabled');
+    target = picker.find('.datepicker-days tbody td:nth(20)');
+    ok(!target.hasClass('disabled'), 'Day of week is disabled');
+    ok(!target.hasClass('disabled-date'), 'Date is disabled');
+    target = picker.find('.datepicker-days tbody td:nth(21)');
+    ok(!target.hasClass('disabled'), 'Day of week is disabled');
+});
+
 test('BeforeShowDay', function(){
 
     var beforeShowDay = function(date) {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| License         | MIT

Useful for when, for instance, you have disabled weekends an wants to enable a specific date that is a weekend.